### PR TITLE
cleanup gcc errors

### DIFF
--- a/src/map.c
+++ b/src/map.c
@@ -749,10 +749,10 @@ void getTerrainHeight(MapInfo* map, Vector2i* coords, int coordLen, float* heigh
 
 
 // calculate a tile's center point in world coordinates
-int tileCenterWorld(MapInfo* map, int tx, int ty, Vector* out) {
+void tileCenterWorld(MapInfo* map, int tx, int ty, Vector* out) {
 	
-	tx = MAX(MIN(tx, TERR_TEX_SZ), 0);
-	ty = MAX(MIN(ty, TERR_TEX_SZ), 0);
+	tx = iclamp(tx, 0, TERR_TEX_SZ);
+	ty = iclamp(ty, 0, TERR_TEX_SZ);
 	
 	float z = map->tb->zs[tx + (ty * TERR_TEX_SZ)];
 	

--- a/src/shader.c
+++ b/src/shader.c
@@ -19,7 +19,7 @@ const char* SHADER_BASE_PATH = "./src/shaders/";
 struct ShaderBuf {
 	char** buffers;
 	int allocSz;
-	int count; 
+	int count;
 	
 };
  
@@ -115,7 +115,7 @@ int extractShader(char** source, GLuint progID) {
 	
 	cnt = sscanf(base + 8, " %23s", typeName); // != 1 for failure
 	if(cnt == EOF || cnt == 0) {
-		return 2; // 
+		return 2; //
 	}
 	
 	
@@ -127,7 +127,7 @@ int extractShader(char** source, GLuint progID) {
 		end = *source + strlen(*source);
 	}
 	
-	printf(" %s", typeName); 
+	printf(" %s", typeName);
 	
 	*source = end;
 	
@@ -188,12 +188,12 @@ int shaderPreProcess(char* path) { // TODO pass in some context
 		// scan the line for preprocessor directives
 		
 		// end of this shader, start of another -- ignore for now
-		end = strstr(base, "#shader"); 
-		end = strstr(base, "#include \"%s\""); 
+		end = strstr(base, "#shader");
+		end = strstr(base, "#include \"%s\"");
 		
 		
 		ws = strspn(readBuf, " \t");
-		if(readBuf[ws] == '#') 
+		if(readBuf[ws] == '#')
 		
 	}
 	
@@ -218,8 +218,8 @@ struct sourceFragment {
 	int lineCount; // number of lines in this fragment
 	GLuint shaderType;
 	
-	struct sourceFragment* next; 
-	struct sourceFragment* prev; 
+	struct sourceFragment* next;
+	struct sourceFragment* prev;
 };
 /* deprecated in favor of just a list of fragments
 struct sourceFile {
@@ -313,7 +313,7 @@ static struct sourceFragment* nibble(char** source) {
 	s += 2; // skip the newline and pound
 	
 	if(0 == strncmp(s, "include", strlen("include"))) {
-		*source = s; 
+		*source = s;
 		
 		fileFrag = nibbleFile(source, frag);
 		
@@ -326,7 +326,7 @@ static struct sourceFragment* nibble(char** source) {
 		if(cnt == EOF || cnt == 0) {
 			free(frag->src);
 			free(frag);
-			return NULL; // 
+			return NULL; //
 		}
 		
 		type = nameToEnum(typeName);
@@ -337,7 +337,7 @@ static struct sourceFragment* nibble(char** source) {
 			return NULL;
 		}
 		
-		// sentinel for shader type change 
+		// sentinel for shader type change
 		fileFrag = calloc(1, sizeof(struct sourceFragment));
 		fileFrag->shaderType = type;
 		fileFrag->src = "";
@@ -366,9 +366,9 @@ static struct sourceFragment* nibbleFile(char** source, struct sourceFragment* p
 	char includeName[256];
 	
 	// extract the file name
-	cnt = sscanf(*source + 9, " \"%255s\"", &includeName); // != 1 for failure
+	cnt = sscanf(*source + 9, " \"%255s\"", includeName); // != 1 for failure
 	if(cnt == EOF || cnt == 0) {
-		return NULL; // invalid parse 
+		return NULL; // invalid parse
 	}
 	
 	
@@ -385,7 +385,7 @@ ShaderProgram* loadCombinedProgram(char* path) {
 	char* source, *spath, *end, *base;
 	int srcLen;
 	char typeName[24];
-	GLenum type; 
+	GLenum type;
 	GLuint id;
 	
 	

--- a/src/shaders/terrain.glsl
+++ b/src/shaders/terrain.glsl
@@ -39,19 +39,19 @@ void main() {
     
 //     gl_TessLevelOuter[0] = tess_in[gl_InvocationID].x; // x
 //     gl_TessLevelOuter[1] = tess_in[gl_InvocationID].y; // y
-//     gl_TessLevelOuter[2] = tess_in[gl_InvocationID].x; // x 
+//     gl_TessLevelOuter[2] = tess_in[gl_InvocationID].x; // x
 //     gl_TessLevelOuter[3] = tess_in[gl_InvocationID].y; // y
-//     
+//
 //     gl_TessLevelInner[0] = tess_in[gl_InvocationID].x;
 //     gl_TessLevelInner[1] = tess_in[gl_InvocationID].y;
-//     
+//
 //     gl_out[gl_InvocationID].gl_Position = gl_in[gl_InvocationID].gl_Position;
-//     
+//
 	if(gl_InvocationID == 0) {
-		gl_TessLevelOuter[0] = 64; 
-		gl_TessLevelOuter[1] = 64; 
-		gl_TessLevelOuter[2] = 64; 
-		gl_TessLevelOuter[3] = 64; 
+		gl_TessLevelOuter[0] = 64;
+		gl_TessLevelOuter[1] = 64;
+		gl_TessLevelOuter[2] = 64;
+		gl_TessLevelOuter[3] = 64;
 	
 		gl_TessLevelInner[0] = 64;
 		gl_TessLevelInner[1] = 64;
@@ -61,7 +61,7 @@ void main() {
 	te_tile[gl_InvocationID] = vs_tile[gl_InvocationID];
 	gl_out[gl_InvocationID].gl_Position = gl_in[gl_InvocationID].gl_Position;
 	
-} 
+}
 
 
 #shader TESS_EVALUATION
@@ -119,14 +119,14 @@ void main(void){
 	float sx = (xp1 - xm1);
 	float sy = (yp1 - ym1);
 
-	te_normal = normalize(vec4(sx*32, sy*32 ,1.0,1.0));
+	te_normal = normalize(vec4(sx*32, sy*32 ,1.0, 1.0));
 	
 
 	tmp.z = t / 1024; // .01 *  sin(gl_TessCoord.y*12) + .01 *sin(gl_TessCoord.x*12);
 
 	gl_Position = (mProj * mView * mModel) * tmp;
-	t_tile =  tltmp; 
-	texCoord = ttmp; 
+	t_tile =  tltmp;
+	texCoord = ttmp;
 }
 
 

--- a/src/text/text.c
+++ b/src/text/text.c
@@ -3,9 +3,6 @@
 #include <stdio.h>
 #include <string.h>
 
-#define MAX(a,b) ((a) > (b) ? a : b)
-#define MIN(a,b) ((a) < (b) ? a : b)
-
 #include <GL/glew.h>
 
 
@@ -263,7 +260,7 @@ TextRenderInfo* prepareText(TextRes* font, const char* str, int len, unsigned in
 	unsigned int defaultColor[] = {0xBADA55FF, INT_MAX}; // you have serious problems if the string is longer than INT_MAX
 	
 	if(!colors)
-		colors = &defaultColor;
+		colors = &defaultColor[0];
 	
 	//TODO:
 	// normalize uv's
@@ -291,15 +288,15 @@ TextRenderInfo* prepareText(TextRes* font, const char* str, int len, unsigned in
 	
 	// vertex
 	glEnableVertexAttribArray(0);
-	glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(TextVertex), 0);
+	glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(TextVertex), (void*)0);
 	glerr("pos attrib");
 	// uvs
 	glEnableVertexAttribArray(1);
-	glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, sizeof(TextVertex), 3*4);
+	glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, sizeof(TextVertex), (void*)(3*4));
 	glerr("uv attrib");
 
 	glEnableVertexAttribArray(2);
-	glVertexAttribPointer(2, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(TextVertex), 5*4);
+	glVertexAttribPointer(2, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(TextVertex), (void*)(5*4));
 	glerr("color attrib");
 
 	
@@ -492,15 +489,15 @@ void updateText(TextRenderInfo* tri, const char* str, int len, unsigned int* col
 	
 		// vertex
 	glEnableVertexAttribArray(0);
-	glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(TextVertex), 0);
+	glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(TextVertex), (void*)0);
 	glerr("pos attrib");
 	// uvs
 	glEnableVertexAttribArray(1);
-	glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, sizeof(TextVertex), 3*4);
+	glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, sizeof(TextVertex), (void*)(3*4));
 	glerr("uv attrib");
 
 	glEnableVertexAttribArray(2);
-	glVertexAttribPointer(2, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(TextVertex), 5*4);
+	glVertexAttribPointer(2, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(TextVertex), (void*)(5*4));
 	glerr("color attrib");
 
 

--- a/src/texture.c
+++ b/src/texture.c
@@ -46,7 +46,7 @@ Texture* loadDataTexture(unsigned char* data, short width, short height) {
 
 	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-	//glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE); 
+	//glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
 
 	// squash the data in
 	glPixelStorei(GL_PACK_ALIGNMENT, 1);
@@ -138,8 +138,9 @@ BitmapRGBA8* readPNG(char* path) {
 	
 	rowPtrs = (png_bytep*)malloc(sizeof(png_bytep) * b->height);
 	
-	for(i = 0; i < b->height; i++)
-		rowPtrs[i] = (png_bytep*)(b->data + (b->width * i));
+	for(i = 0; i < b->height; i++) {
+		rowPtrs[i] = (png_bytep)(b->data + (b->width * i));
+	}
 
 	png_read_image(readStruct, rowPtrs);
 
@@ -157,7 +158,7 @@ BitmapRGBA8* readPNG(char* path) {
 
 Texture* loadBitmapTexture(char* path) {
 
-	BitmapRGBA8* png; 
+	BitmapRGBA8* png;
 	
 	
 	
@@ -186,7 +187,7 @@ Texture* loadBitmapTexture(char* path) {
 
 	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-	//glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE); 
+	//glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
 
 	// squash the data in
 	glPixelStorei(GL_PACK_ALIGNMENT, 1);
@@ -271,17 +272,17 @@ TexArray* loadTexArray(char** files) {
 	
 	glTexParameterf(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 	glTexParameterf(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-	glTexParameterf(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE); 
+	glTexParameterf(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
 	glexit("failed to create texture array 3");
 	
 	// squash the data in
 	glPixelStorei(GL_PACK_ALIGNMENT, 1);
 	glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 	
-	glTexStorage3D(GL_TEXTURE_2D_ARRAY, 
+	glTexStorage3D(GL_TEXTURE_2D_ARRAY,
 		1,  // mips, flat
-		GL_RGBA8, 
-		w, h, 
+		GL_RGBA8,
+		w, h,
 		len); // layers
 	
 	glexit("failed to create texture array 4");

--- a/src/utilities.c
+++ b/src/utilities.c
@@ -137,13 +137,6 @@ GLuint makeVAO(VAOConfig* details, int stride) {
 }
 
 
-int iclamp(int val, int min, int max) {
-	return MIN(max, MAX(min, val));
-}
-
-int iclampNorm(int val) {
-	return iclamp(val, 0, 1);
-}
 
 float fclamp(float val, float min, float max) {
 	return fmin(max, fmax(min, val));
@@ -151,6 +144,14 @@ float fclamp(float val, float min, float max) {
 
 float fclampNorm(float val) {
 	return fclamp(val, 0.0f, 1.0f);
+}
+
+int iclamp(int val, int min, int max) {
+	return MIN(max, MAX(min, val));
+}
+
+int iclampNorm(int val) {
+	return iclamp(val, 0, 1);
 }
 
 

--- a/src/utilities.c
+++ b/src/utilities.c
@@ -103,7 +103,8 @@ char* readFile(char* path, int* srcLen) {
 
 
 GLuint makeVAO(VAOConfig* details, int stride) {
-	int i, offset; // packed data is expected
+	int i; // packed data is expected
+	uintptr_t offset = 0;
 	GLuint vao;
 	
 	glGenVertexArrays(1, &vao);
@@ -136,6 +137,14 @@ GLuint makeVAO(VAOConfig* details, int stride) {
 }
 
 
+int iclamp(int val, int min, int max) {
+	return MIN(max, MAX(min, val));
+}
+
+int iclampNorm(int val) {
+	return iclamp(val, 0, 1);
+}
+
 float fclamp(float val, float min, float max) {
 	return fmin(max, fmax(min, val));
 }
@@ -147,9 +156,13 @@ float fclampNorm(float val) {
 
 // strdup a line
 char* strlndup(const char* s) {
-	int n;
+	char* n;
+	
 	n = strchr(s, '\n');
-	if(!n) return strdup(s);
-	return strndup(s, n);
+	if(!n) {
+		return strdup(s);
+	}
+	
+	return strndup(s, n-s);
 }
 

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -93,6 +93,9 @@ void initKHRDebug();
 float fclamp(float val, float min, float max);
 float fclampNorm(float val);
 
+int iclamp(int val, int min, int max);
+int iclampNorm(int val);
+
 char* strlndup(const char* s);
 
 #endif // __EACSMB_UTILITIES_H__

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -12,7 +12,6 @@
 #define glerr(msg) _glerr(msg, __FILE__, __LINE__, __func__)
 
 
-// yeah yeah double evaluation. i'm only using them with variables and constants so shut up.
 #define MAX(a,b) ({ \
 	__typeof__ (a) _a = (a); \
 	__typeof__ (b) _b = (b); \

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -13,10 +13,26 @@
 
 
 // yeah yeah double evaluation. i'm only using them with variables and constants so shut up.
-#define MAX(a,b) ((a) > (b) ?  (a) : (b))
-#define MIN(a,b) ((a) < (b) ?  (a) : (b))
-#define MAXE(a,b) ((a) >= (b) ?  (a) : (b))
-#define MINE(a,b) ((a) <= (b) ?  (a) : (b))
+#define MAX(a,b) ({ \
+	__typeof__ (a) _a = (a); \
+	__typeof__ (b) _b = (b); \
+	_a > _b ? _a : _b; \
+})
+#define MIN(a,b) ({ \
+	__typeof__ (a) _a = (a); \
+	__typeof__ (b) _b = (b); \
+	_a < _b ? _a : _b; \
+})
+#define MAXE(a,b) ({ \
+	__typeof__ (a) _a = (a); \
+	__typeof__ (b) _b = (b); \
+	_a >= _b ? _a : _b; \
+})
+#define MINE(a,b) ({ \
+	__typeof__ (a) _a = (a); \
+	__typeof__ (b) _b = (b); \
+	_a <= _b ? _a : _b; \
+})
 
 
 


### PR DESCRIPTION
- integer range clamping functions `iclamp` and `iclampNorm` 
- remove double definition of MIN/MAX
- use MIN/MAX implementations without double evaluation
- fix strlndup
